### PR TITLE
Keeping QuotationMark from parent object of ObjectFactory. 

### DIFF
--- a/EFSqlTranslator.Translation/DbObjects/DbKeyValue.cs
+++ b/EFSqlTranslator.Translation/DbObjects/DbKeyValue.cs
@@ -6,6 +6,8 @@ namespace EFSqlTranslator.Translation.DbObjects
         {
             Key = key;
             Value = val;
+
+            OutputOption = val?.OutputOption;
         }
 
         public string Key { get; private set; }

--- a/EFSqlTranslator.Translation/DbObjects/DbReference.cs
+++ b/EFSqlTranslator.Translation/DbObjects/DbReference.cs
@@ -9,6 +9,8 @@ namespace EFSqlTranslator.Translation.DbObjects
         public DbReference(IDbObject dbObject)
         {
             Referee = dbObject;
+
+            OutputOption = dbObject?.OutputOption;
         }
 
         public IDbObject Referee { get; }

--- a/EFSqlTranslator.Translation/DbObjects/SqlObjects/SqlObjectFactory.cs
+++ b/EFSqlTranslator.Translation/DbObjects/SqlObjects/SqlObjectFactory.cs
@@ -29,7 +29,8 @@ namespace EFSqlTranslator.Translation.DbObjects.SqlObjects
         {
             var dbSelect = new SqlSelect
             {
-                From = dbReference
+                From = dbReference,
+                OutputOption = dbReference.OutputOption
             };
 
             dbReference.OwnerSelect = dbSelect;
@@ -196,7 +197,8 @@ namespace EFSqlTranslator.Translation.DbObjects.SqlObjects
         {
             return new DbReference(dbObj)
             {
-                Alias = alias
+                Alias = alias,
+                OutputOption = OutputOption
             };
         }
 

--- a/EFSqlTranslator.Translation/DbObjects/SqliteObjects/SqliteObjectFactory.cs
+++ b/EFSqlTranslator.Translation/DbObjects/SqliteObjects/SqliteObjectFactory.cs
@@ -31,7 +31,8 @@ namespace EFSqlTranslator.Translation.DbObjects.SqliteObjects
         {
             return new SqliteFunc(name, parameters)
             {
-                IsAggregation = isAggregation
+                IsAggregation = isAggregation,
+                OutputOption = OutputOption
             };
         }
         


### PR DESCRIPTION
Allows to avoid default single quote symbol using for column names (it is prohibited in PostgreSQL).

e.g. such query

context.MyItems
                    .GroupBy(x => x.CategoryId)
                    .Select(g => new { g.Key, Cnt = g.Count() });

generated this SQL:

select d0."defect_category_id" as "Key", count(1) as 'Cnt'
  from public."my_items" d0
  group by d0."category_id"

It causes a syntax error in PostgreSQL