### PR TITLE
DistinctCountTranslationTests added.

### DIFF
--- a/EFSqlTranslator.Tests/TranslatorTests/AggregationTranslationTests.cs
+++ b/EFSqlTranslator.Tests/TranslatorTests/AggregationTranslationTests.cs
@@ -267,31 +267,5 @@ group by sq0.BlogId, sq0.Url, u0.UserName";
                 TestUtils.AssertStringEqual(expected, sql);
             }
         }
-
-        [Fact]
-        public void Test_Distinc_count()
-        {
-            using (var db = new TestingContext())
-            {
-                var query = db.Posts.
-                    Where(p => p.Content != null).
-                    Select(g => new
-                    {
-                        g.BlogId,
-                        cnt = g.Comments.DistinctCount(c => c.User.UserName)
-                    });
-
-                var script = QueryTranslator.Translate(query.Expression, new EFModelInfoProvider(db), new SqliteObjectFactory());
-                var sql = script.ToString();
-
-                const string expected = @"
-select p0.BlogId, count(distinct u0.UserName) as 'cnt', c0.PostId as 'PostId_jk0'
-from Comments c0
-inner join Users u0 on c0.UserId = u0.UserId
-group by c0.PostId, p0.BlogId";
-
-                TestUtils.AssertStringEqual(expected, sql);
-            }
-        }
     }
 }

--- a/EFSqlTranslator.Tests/TranslatorTests/DistinctCountTranslationTests.cs
+++ b/EFSqlTranslator.Tests/TranslatorTests/DistinctCountTranslationTests.cs
@@ -1,0 +1,61 @@
+﻿using System.Linq;
+using EFSqlTranslator.EFModels;
+using EFSqlTranslator.Translation;
+using EFSqlTranslator.Translation.DbObjects.SqliteObjects;
+using EFSqlTranslator.Translation.Extensions;
+using Xunit;
+
+namespace EFSqlTranslator.Tests.TranslatorTests
+{
+    public class DistinctCountTranslationTests
+    {
+        [Fact]
+        public void Test_DistinctCount_In_GroupBy()
+        {
+            using (var db = new TestingContext())
+            {
+                var query = db.Posts.
+                    Where(p => p.Content != null).
+                    GroupBy(p => p.BlogId).
+                    Select(g => new { cnt = g.DistinctCount(p => p.UserId) });
+
+                var script = QueryTranslator.Translate(query.Expression, new EFModelInfoProvider(db), new SqliteObjectFactory());
+                var sql = script.ToString();
+
+                const string expected = @"
+select count(distinct p0.UserId) as 'cnt'
+from Posts p0
+where p0.Content is not null
+group by p0.BlogId";
+
+                TestUtils.AssertStringEqual(expected, sql);
+            }
+        }
+
+        [Fact]
+        public void Test_DistinctCount_On_Child_Relation()
+        {
+            using (var db = new TestingContext())
+            {
+                var query = db.Posts.
+                    Where(p => p.Content != null).
+                    Select(g => new
+                    {
+                        g.BlogId,
+                        cnt = g.Comments.DistinctCount(c => c.User.UserName)
+                    });
+
+                var script = QueryTranslator.Translate(query.Expression, new EFModelInfoProvider(db), new SqliteObjectFactory());
+                var sql = script.ToString();
+
+                const string expected = @"
+select p0.BlogId, count(distinct u0.UserName) as 'cnt', c0.PostId as 'PostId_jk0'
+from Comments c0
+inner join Users u0 on c0.UserId = u0.UserId
+group by c0.PostId, p0.BlogId";
+
+                TestUtils.AssertStringEqual(expected, sql);
+            }
+        }
+    }
+}

--- a/EFSqlTranslator.Translation/MethodTranslators/AggregationTranslator.cs
+++ b/EFSqlTranslator.Translation/MethodTranslators/AggregationTranslator.cs
@@ -55,15 +55,6 @@ namespace EFSqlTranslator.Translation.MethodTranslators
             CreateAggregation(m, state, nameGenerator, childSelect, dbCountFunc);
         }
 
-        private static IDbSelectable GetAggregationTarget(MethodCallExpression m, TranslationState state)
-        {
-            if (!m.GetArguments().Any())
-                return null;
-
-            var dbObj = state.ResultStack.Pop();
-            return (IDbSelectable)dbObj;
-        }
-
         private static string GetSqlMethodName(string methodName)
         {
             methodName = methodName.ToLower();

--- a/EFSqlTranslator.Translation/MethodTranslators/AggregationTranslatorBase.cs
+++ b/EFSqlTranslator.Translation/MethodTranslators/AggregationTranslatorBase.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using System.Linq.Expressions;
 using EFSqlTranslator.Translation.DbObjects;
+using EFSqlTranslator.Translation.Extensions;
 
 namespace EFSqlTranslator.Translation.MethodTranslators
 {
@@ -54,6 +55,15 @@ namespace EFSqlTranslator.Translation.MethodTranslators
             var dbIsNullFunc = _dbFactory.BuildNullCheckFunc(column, dbDefaultVal);
 
             state.ResultStack.Push(dbIsNullFunc);
+        }
+
+        protected static IDbSelectable GetAggregationTarget(MethodCallExpression m, TranslationState state)
+        {
+            if (!m.GetArguments().Any())
+                return null;
+
+            var dbObj = state.ResultStack.Pop();
+            return (IDbSelectable)dbObj;
         }
 
         private void ReLinkToChildSelect(IDbSelect dbSelect, IDbSelect childSelect) 

--- a/EFSqlTranslator.Translation/MethodTranslators/DistinctCountTranslator.cs
+++ b/EFSqlTranslator.Translation/MethodTranslators/DistinctCountTranslator.cs
@@ -1,7 +1,8 @@
 ﻿using System;
+using System.Linq;
 using System.Linq.Expressions;
-
 using EFSqlTranslator.Translation.DbObjects;
+using EFSqlTranslator.Translation.Extensions;
 
 namespace EFSqlTranslator.Translation.MethodTranslators
 {
@@ -24,24 +25,44 @@ namespace EFSqlTranslator.Translation.MethodTranslators
         public override void Translate(
             MethodCallExpression m, TranslationState state, UniqueNameGenerator nameGenerator)
         {
-            var dbExpression = (IDbSelectable)state.ResultStack.Pop();
+            var dbExpression = GetAggregationTarget(m, state);
+
+            IDbSelect childSelect = null;
+            if (!m.GetCaller().Type.IsGrouping())
+                childSelect = state.ResultStack.Pop() as IDbSelect;
+
+            // if the aggregation does not have expression, it means
+            // the caller of the aggregation method must be a Select method call
+            // In this case, the actual expression that we need to aggregate on,
+            // will be inside the child select statement
+            if (dbExpression == null && childSelect != null)
+            {
+                // to get the actual expression, we need to first unwrap the child select
+                // because the translation of Select call always wrap the actual select
+                childSelect = (IDbSelect)childSelect.From.Referee;
+
+                dbExpression = childSelect.Selection.Last(
+                    s => string.IsNullOrEmpty(s.Alias) ||
+                         !s.Alias.EndsWith(TranslationConstants.JoinKeySuffix));
+
+                childSelect.Selection.Remove(dbExpression);
+                childSelect.GroupBys.Remove(dbExpression);
+            }
 
             if (dbExpression == null)
-            {
                 throw new NotSupportedException("Can not aggregate.");
-            }
 
             if (!(dbExpression is IDistinctable))
             {
                 throw new NotSupportedException("Expression must be Distinctable");
             }
-            
+
             var distinctable = (IDistinctable)dbExpression;
             distinctable.IsDistinct = true;
-            
+
             var dbFunc = _dbFactory.BuildFunc("count", true, dbExpression);
 
-            CreateAggregation(m, state, nameGenerator, null, dbFunc);
+            CreateAggregation(m, state, nameGenerator, childSelect, dbFunc);
         }
     }
 }


### PR DESCRIPTION
Hello!
I was overloaded last week, thank you for commiting the test.

I found, DistinctCount worked right only with GroupBy LINQ function. I added test for this case.

But also we can use DistinctCount on child relation (InverseProperty)
`var query = db.Blogs.Select(b => new { b.Name, cnt = b.Posts.DistinctCount(p => p.PostId)});`
It worked wrong way. I fixed and changed a relevant test.